### PR TITLE
Remove renderer and tree on teardown to prevent memory leaks

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -36,7 +36,8 @@ BenchmarkImpl.prototype.setUp = function() {
 };
 
 BenchmarkImpl.prototype.tearDown = function() {
-  // this.renderer.remove();
+  this.renderer.remove();
+  this.tree.unmount();
 };
 
 BenchmarkImpl.prototype.render = function() {


### PR DESCRIPTION
See dekujs/deku#180
